### PR TITLE
Fix relative include path for clang lib headers

### DIFF
--- a/mlir-clang/Lib/clang-mlir.h
+++ b/mlir-clang/Lib/clang-mlir.h
@@ -25,8 +25,8 @@
 #include "pragmaHandler.h"
 #include "llvm/IR/DerivedTypes.h"
 
-#include "../../llvm-project/clang/lib/CodeGen/CGRecordLayout.h"
-#include "../../llvm-project/clang/lib/CodeGen/CodeGenModule.h"
+#include "clang/../../lib/CodeGen/CGRecordLayout.h"
+#include "clang/../../lib/CodeGen/CodeGenModule.h"
 #include "clang/AST/Mangle.h"
 
 using namespace clang;


### PR DESCRIPTION
A source-relative include path was used to include the headers in question, leading to an issue if building Polygeist with an out-of-tree llvm/clang build.
The proposed fix uses the "clang/..." (include) directory as a starting point and locates the lib headers relative to this. This should (hopefully) work for any in- and out-of-tree build.