### PR TITLE
Remove static variables from MLIRAction

### DIFF
--- a/mlir-clang/Lib/clang-mlir.cc
+++ b/mlir-clang/Lib/clang-mlir.cc
@@ -5219,23 +5219,18 @@ void MLIRScanner::popLoopIf() {
 class MLIRAction : public clang::ASTFrontendAction {
 public:
   std::set<std::string> emitIfFound;
-  std::set<std::string> done;
   mlir::OwningOpRef<mlir::ModuleOp> &module;
-  std::map<std::string, mlir::LLVM::GlobalOp> llvmStringGlobals;
-  std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> globals;
-  std::map<std::string, mlir::FuncOp> functions;
-  std::map<std::string, mlir::LLVM::GlobalOp> llvmGlobals;
-  std::map<std::string, mlir::LLVM::LLVMFuncOp> llvmFunctions;
+
   MLIRAction(std::string fn, mlir::OwningOpRef<mlir::ModuleOp> &module)
       : module(module) {
     emitIfFound.insert(fn);
   }
+
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(CompilerInstance &CI, StringRef InFile) override {
-    return std::unique_ptr<clang::ASTConsumer>(new MLIRASTConsumer(
-        emitIfFound, done, llvmStringGlobals, globals, functions, llvmGlobals,
-        llvmFunctions, CI.getPreprocessor(), CI.getASTContext(), module,
-        CI.getSourceManager()));
+    return std::unique_ptr<clang::ASTConsumer>(
+        new MLIRASTConsumer(emitIfFound, CI.getPreprocessor(),
+                            CI.getASTContext(), module, CI.getSourceManager()));
   }
 };
 

--- a/mlir-clang/Lib/clang-mlir.h
+++ b/mlir-clang/Lib/clang-mlir.h
@@ -300,12 +300,14 @@ struct ValueWithOffsets {
 
 struct MLIRASTConsumer : public ASTConsumer {
   std::set<std::string> &emitIfFound;
-  std::set<std::string> &done;
-  std::map<std::string, mlir::LLVM::GlobalOp> &llvmStringGlobals;
-  std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &globals;
-  std::map<std::string, mlir::FuncOp> &functions;
-  std::map<std::string, mlir::LLVM::GlobalOp> &llvmGlobals;
-  std::map<std::string, mlir::LLVM::LLVMFuncOp> &llvmFunctions;
+
+  std::set<std::string> done;
+  std::map<std::string, mlir::LLVM::GlobalOp> llvmStringGlobals;
+  std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> globals;
+  std::map<std::string, mlir::FuncOp> functions;
+  std::map<std::string, mlir::LLVM::GlobalOp> llvmGlobals;
+  std::map<std::string, mlir::LLVM::LLVMFuncOp> llvmFunctions;
+
   Preprocessor &PP;
   ASTContext &astContext;
   mlir::OwningOpRef<mlir::ModuleOp> &module;
@@ -322,19 +324,11 @@ struct MLIRASTConsumer : public ASTConsumer {
   LLVM::TypeFromLLVMIRTranslator typeTranslator;
   LLVM::TypeToLLVMIRTranslator reverseTypeTranslator;
 
-  MLIRASTConsumer(
-      std::set<std::string> &emitIfFound, std::set<std::string> &done,
-      std::map<std::string, mlir::LLVM::GlobalOp> &llvmStringGlobals,
-      std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &globals,
-      std::map<std::string, mlir::FuncOp> &functions,
-      std::map<std::string, mlir::LLVM::GlobalOp> &llvmGlobals,
-      std::map<std::string, mlir::LLVM::LLVMFuncOp> &llvmFunctions,
-      Preprocessor &PP, ASTContext &astContext,
-      mlir::OwningOpRef<mlir::ModuleOp> &module, clang::SourceManager &SM)
-      : emitIfFound(emitIfFound), done(done),
-        llvmStringGlobals(llvmStringGlobals), globals(globals),
-        functions(functions), llvmGlobals(llvmGlobals),
-        llvmFunctions(llvmFunctions), PP(PP), astContext(astContext),
+  MLIRASTConsumer(std::set<std::string> &emitIfFound, Preprocessor &PP,
+                  ASTContext &astContext,
+                  mlir::OwningOpRef<mlir::ModuleOp> &module,
+                  clang::SourceManager &SM)
+      : emitIfFound(emitIfFound), PP(PP), astContext(astContext),
         module(module), SM(SM), lcontext(), llvmMod("tmp", lcontext),
         codegenops(),
         CGM(astContext, PP.getHeaderSearchInfo().getHeaderSearchOpts(),


### PR DESCRIPTION
MLIRActions was storing a couple of maps/set that were not used by the class,
but just passed by reference to MLIRASTConsumer, that was using name. Store
them in MLIRASTConsumer directly.