### PR TITLE
[CMake] Add MLIRNVVMIR to LINK_LIBS for MLIRPolygeistTransforms.

### DIFF
--- a/lib/polygeist/Passes/CMakeLists.txt
+++ b/lib/polygeist/Passes/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRIR
   MLIRLLVMIR
   MLIRMemRef
+  MLIRNVVMIR
   MLIRPass
   MLIRPolygeist
   MLIRSideEffectInterfaces


### PR DESCRIPTION
This dependency is necessary, e.g. when using BUILD_SHARED_LIBS.