### PR TITLE
Fixed linkage issue due to incorrect macro defs

### DIFF
--- a/mlir-clang/CMakeLists.txt
+++ b/mlir-clang/CMakeLists.txt
@@ -1,17 +1,3 @@
-add_clang_tool(mlir-clang
-  "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1_main.cpp"
-  "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1as_main.cpp"
-  "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1gen_reproducer_main.cpp"
-  mlir-clang.cc
-  Lib/utils.cc
-  Lib/pragmaHandler.cc
-)
-
-target_include_directories(mlir-clang PRIVATE
-  "${LLVM_SOURCE_DIR}/../clang/include"
-  "${CMAKE_BINARY_DIR}/tools/clang/include"
-)
-
 set( LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   Analysis
@@ -28,16 +14,24 @@ set( LLVM_LINK_COMPONENTS
   Support
   TransformUtils
   Vectorize
-  )
+)
 
-list(TRANSFORM LLVM_LINK_COMPONENTS PREPEND LLVM)
+add_clang_tool(mlir-clang
+  "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1_main.cpp"
+  "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1as_main.cpp"
+  "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1gen_reproducer_main.cpp"
+  mlir-clang.cc
+  Lib/utils.cc
+  Lib/pragmaHandler.cc
+)
 
+target_include_directories(mlir-clang PRIVATE
+  "${LLVM_SOURCE_DIR}/../clang/include"
+  "${CMAKE_BINARY_DIR}/tools/clang/include"
+)
 
 target_compile_definitions(mlir-clang PUBLIC -DLLVM_OBJ_ROOT="${LLVM_BINARY_DIR}")
 target_link_libraries(mlir-clang PRIVATE
-    #    ${LLVM_LINK_COMPONENTS}
-    ${LLVM_AVAILABLE_LIBS}
-
   MLIRSCFTransforms
   MLIRPolygeist
 


### PR DESCRIPTION
Fixes #84 


It seems that we should define `LLVM_LINK_COMPONENTS` before `add_clang_tools`. 