### PR TITLE
Add a polygeist-opt tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
+option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
 
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(polygeist LANGUAGES CXX C)
@@ -70,3 +72,4 @@ include(sanitizers)
 add_subdirectory(include)
 add_subdirectory(mlir-clang)
 add_subdirectory(lib)
+add_subdirectory(tools)

--- a/include/polygeist/Passes/Passes.h
+++ b/include/polygeist/Passes/Passes.h
@@ -1,3 +1,6 @@
+#ifndef POLYGEIST_DIALECT_POLYGEIST_PASSES_H
+#define POLYGEIST_DIALECT_POLYGEIST_PASSES_H
+
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
@@ -8,13 +11,15 @@ std::unique_ptr<OperationPass<FuncOp>> createLoopRestructurePass();
 std::unique_ptr<OperationPass<FuncOp>> replaceAffineCFGPass();
 std::unique_ptr<Pass> createCanonicalizeForPass();
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
-std::unique_ptr<Pass> createCPUifyPass(std::string);
+std::unique_ptr<Pass> createCPUifyPass(StringRef method = "");
 std::unique_ptr<Pass> createBarrierRemovalContinuation();
 std::unique_ptr<OperationPass<FuncOp>> detectReductionPass();
 std::unique_ptr<OperationPass<FuncOp>> createRemoveTrivialUsePass();
 std::unique_ptr<Pass> createParallelLowerPass();
 std::unique_ptr<Pass>
 createConvertPolygeistToLLVMPass(const LowerToLLVMOptions &options);
+std::unique_ptr<Pass> createConvertPolygeistToLLVMPass();
+
 } // namespace polygeist
 } // namespace mlir
 
@@ -41,7 +46,9 @@ namespace LLVM {
 class LLVMDialect;
 }
 
-#define GEN_PASS_CLASSES
+#define GEN_PASS_REGISTRATION
 #include "polygeist/Passes/Passes.h.inc"
 
 } // end namespace mlir
+
+#endif // POLYGEIST_DIALECT_POLYGEIST_PASSES_H

--- a/include/polygeist/Passes/Passes.td
+++ b/include/polygeist/Passes/Passes.td
@@ -5,58 +5,58 @@ include "mlir/Pass/PassBase.td"
 
 def AffineCFG : FunctionPass<"affine-cfg"> {
   let summary = "Replace scf.if and similar with affine.if";
-  let constructor = "mlir::replaceAffineCFGPass()";
+  let constructor = "mlir::polygeist::replaceAffineCFGPass()";
 }
 
 def Mem2Reg : FunctionPass<"mem2reg"> {
   let summary = "Replace scf.if and similar with affine.if";
-  let constructor = "mlir::replaceAffineCFGPass()";
+  let constructor = "mlir::polygeist::replaceAffineCFGPass()";
 }
 
-def ParallelLower : Pass<"parallel-lower", "ModuleOp"> {
+def ParallelLower : Pass<"parallel-lower", "mlir::ModuleOp"> {
   let summary = "Replace scf.if and similar with affine.if";
-  let constructor = "mlir::createParallelLowerPass()";
+  let constructor = "mlir::polygeist::createParallelLowerPass()";
 }
 
 def AffineReduction : FunctionPass<"detect-reduction"> {
   let summary = "Detect reductions in affine.for";
-  let constructor = "mlir::detectReductionPass()";
+  let constructor = "mlir::polygeist::detectReductionPass()";
 }
 
 def SCFCPUify : FunctionPass<"cpuify"> {
   let summary = "remove scf.barrier";
-  let constructor = "mlir::createCPUifyPass()";
+  let constructor = "mlir::polygeist::createCPUifyPass()";
   let dependentDialects =
       ["memref::MemRefDialect", "StandardOpsDialect", "LLVM::LLVMDialect"];
 }
 
 def SCFBarrierRemovalContinuation : FunctionPass<"barrier-removal-continuation"> {
   let summary = "Remove scf.barrier using continuations";
-  let constructor = "mlir::createBarrierRemovalContinuation()";
+  let constructor = "mlir::polygeist::createBarrierRemovalContinuation()";
   let dependentDialects = ["memref::MemRefDialect", "StandardOpsDialect"];
 }
 
 def SCFRaiseToAffine : FunctionPass<"raise-scf-to-affine"> {
   let summary = "Raise SCF to affine";
-  let constructor = "mlir::createRaiseSCFToAffinePass()";
+  let constructor = "mlir::polygeist::createRaiseSCFToAffinePass()";
   let dependentDialects = ["AffineDialect"];
 }
 
 def SCFCanonicalizeFor : FunctionPass<"canonicalize-scf-for"> {
   let summary = "Run some additional canonicalization for scf::for";
-  let constructor = "mlir::createCanonicalizeForPass()";
+  let constructor = "mlir::polygeist::createCanonicalizeForPass()";
 }
 
 def LoopRestructure : FunctionPass<"loop-restructure"> {
-  let constructor = "mlir::createLoopRestructurePass()";
+  let constructor = "mlir::polygeist::createLoopRestructurePass()";
   let dependentDialects = ["::mlir::scf::SCFDialect"];
 }
 
 def RemoveTrivialUse : FunctionPass<"trivialuse"> {
-  let constructor = "mlir::createRemoveTrivialUse()";
+  let constructor = "mlir::polygeist::createRemoveTrivialUsePass()";
 }
 
-def ConvertPolygeistToLLVM : Pass<"convert-polygeist-to-llvm", "ModuleOp"> {
+def ConvertPolygeistToLLVM : Pass<"convert-polygeist-to-llvm", "mlir::ModuleOp"> {
   let summary = "Convert scalar and vector operations from the Standard to the "
                 "LLVM dialect";
   let description = [{
@@ -83,7 +83,7 @@ def ConvertPolygeistToLLVM : Pass<"convert-polygeist-to-llvm", "ModuleOp"> {
     returns are updated accordingly. Block argument types are updated to use
     LLVM IR types.
   }];
-  let constructor = "mlir::createConvertPolygeistToLLVMPass()";
+  let constructor = "mlir::polygeist::createConvertPolygeistToLLVMPass()";
   let dependentDialects = ["LLVM::LLVMDialect"];
   let options = [
     Option<"useBarePtrCallConv", "use-bare-ptr-memref-call-conv", "bool",

--- a/lib/polygeist/Passes/AffineCFG.cpp
+++ b/lib/polygeist/Passes/AffineCFG.cpp
@@ -1,3 +1,5 @@
+#include "PassDetails.h"
+
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -14,6 +16,7 @@
 
 using namespace mlir;
 using namespace mlir::arith;
+using namespace polygeist;
 
 struct AffineApplyNormalizer {
   AffineApplyNormalizer(AffineMap map, ArrayRef<Value> operands);

--- a/lib/polygeist/Passes/AffineReduction.cpp
+++ b/lib/polygeist/Passes/AffineReduction.cpp
@@ -1,3 +1,5 @@
+#include "PassDetails.h"
+
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -7,6 +9,7 @@
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
+using namespace polygeist;
 
 namespace {
 struct AffineReductionPass : public AffineReductionBase<AffineReductionPass> {

--- a/lib/polygeist/Passes/BarrierRemovalContinuation.cpp
+++ b/lib/polygeist/Passes/BarrierRemovalContinuation.cpp
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PassDetails.h"
+
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Passes.h"

--- a/lib/polygeist/Passes/CanonicalizeFor.cpp
+++ b/lib/polygeist/Passes/CanonicalizeFor.cpp
@@ -1,3 +1,5 @@
+#include "PassDetails.h"
+
 #include "mlir/Dialect/SCF/Passes.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -10,6 +12,7 @@
 using namespace mlir;
 using namespace mlir::scf;
 using namespace mlir::arith;
+using namespace polygeist;
 
 namespace {
 struct CanonicalizeFor : public SCFCanonicalizeForBase<CanonicalizeFor> {

--- a/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -9,9 +9,7 @@
 // This file implements a pass to lower gpu kernels in NVVM/gpu dialects into
 // a generic parallel for representation
 //===----------------------------------------------------------------------===//
-
-#include "polygeist/Ops.h"
-#include "polygeist/Passes/Passes.h"
+#include "PassDetails.h"
 
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
@@ -25,6 +23,7 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/StandardOps/Transforms/Passes.h"
+#include "polygeist/Ops.h"
 
 #define DEBUG_TYPE "convert-polygeist-to-llvm"
 
@@ -300,4 +299,13 @@ std::unique_ptr<Pass> mlir::polygeist::createConvertPolygeistToLLVMPass(
   return std::make_unique<ConvertPolygeistToLLVMPass>(
       options.useBarePtrCallConv, options.emitCWrappers,
       options.getIndexBitwidth(), useAlignedAlloc, options.dataLayout);
+}
+
+std::unique_ptr<Pass> mlir::polygeist::createConvertPolygeistToLLVMPass() {
+  // TODO: meaningful arguments to this pass should be specified as
+  // Option<...>'s to the pass in Passes.td. For now, we'll provide some dummy
+  // default values to allow for pass creation.
+  auto dl = llvm::DataLayout("");
+  return std::make_unique<ConvertPolygeistToLLVMPass>(true, true, 64u, true,
+                                                      dl);
 }

--- a/lib/polygeist/Passes/LoopRestructure.cpp
+++ b/lib/polygeist/Passes/LoopRestructure.cpp
@@ -62,6 +62,8 @@ func @kernel_gemm(%arg0: i32, %arg1: memref<?xf64>) {
   return
 }
 */
+#include "PassDetails.h"
+
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -81,6 +83,7 @@ func @kernel_gemm(%arg0: i32, %arg1: memref<?xf64>) {
 #define DEBUG_TYPE "LoopRestructure"
 
 using namespace mlir;
+using namespace polygeist;
 
 struct Wrapper;
 
@@ -235,7 +238,7 @@ struct GraphTraits<const DomTreeNodeBase<Wrapper> *>
 
 namespace {
 
-struct LoopRestructure : public mlir::LoopRestructureBase<LoopRestructure> {
+struct LoopRestructure : public LoopRestructureBase<LoopRestructure> {
   void runOnRegion(DominanceInfo &domInfo, Region &region);
   bool removeIfFromRegion(DominanceInfo &domInfo, Region &region,
                           Block *pseudoExit);

--- a/lib/polygeist/Passes/Mem2Reg.cpp
+++ b/lib/polygeist/Passes/Mem2Reg.cpp
@@ -12,6 +12,7 @@
 // dead memref store's and perform more complex forwarding when support for
 // SSA scalars live out of 'affine.for'/'affine.if' statements is available.
 //===----------------------------------------------------------------------===//
+#include "PassDetails.h"
 
 #include "mlir/Analysis/AffineAnalysis.h"
 #include "mlir/Analysis/Utils.h"
@@ -36,6 +37,7 @@
 
 using namespace mlir;
 using namespace mlir::arith;
+using namespace polygeist;
 
 typedef std::set<std::vector<ssize_t>> StoreMap;
 

--- a/lib/polygeist/Passes/ParallelLoopDistribute.cpp
+++ b/lib/polygeist/Passes/ParallelLoopDistribute.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "PassDetails.h"
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -30,6 +31,7 @@
 
 using namespace mlir;
 using namespace mlir::arith;
+using namespace polygeist;
 
 /// Populates `crossing` with values (op results) that are defined in the same
 /// block as `op` and above it, and used by at least one op in the same block
@@ -938,8 +940,8 @@ struct Reg2MemWhile : public OpRewritePattern<scf::WhileOp> {
 };
 
 struct CPUifyPass : public SCFCPUifyBase<CPUifyPass> {
-  std::string method;
-  CPUifyPass(std::string method) : method(method) {}
+  StringRef method;
+  CPUifyPass(StringRef method) : method(method) {}
   void runOnFunction() override {
     if (method == "distribute") {
       OwningRewritePatternList patterns(&getContext());
@@ -974,7 +976,7 @@ struct CPUifyPass : public SCFCPUifyBase<CPUifyPass> {
 
 namespace mlir {
 namespace polygeist {
-std::unique_ptr<Pass> createCPUifyPass(std::string str) {
+std::unique_ptr<Pass> createCPUifyPass(StringRef str) {
   return std::make_unique<CPUifyPass>(str);
 }
 } // namespace polygeist

--- a/lib/polygeist/Passes/ParallelLower.cpp
+++ b/lib/polygeist/Passes/ParallelLower.cpp
@@ -9,6 +9,7 @@
 // This file implements a pass to lower gpu kernels in NVVM/gpu dialects into
 // a generic parallel for representation
 //===----------------------------------------------------------------------===//
+#include "PassDetails.h"
 
 #include "mlir/Analysis/AffineAnalysis.h"
 #include "mlir/Analysis/CallGraph.h"
@@ -32,6 +33,7 @@
 
 using namespace mlir;
 using namespace mlir::arith;
+using namespace polygeist;
 
 namespace {
 // The store to load forwarding relies on three conditions:

--- a/lib/polygeist/Passes/PassDetails.h
+++ b/lib/polygeist/Passes/PassDetails.h
@@ -1,0 +1,33 @@
+//===- PassDetails.h - polygeist pass class details ----------------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Stuff shared between the different polygeist passes.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-tidy seems to expect the absolute path in the header guard on some
+// systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_POLYGEIST_TRANSFORMS_PASSDETAILS_H
+#define DIALECT_POLYGEIST_TRANSFORMS_PASSDETAILS_H
+
+#include "polygeist/Ops.h"
+#include "mlir/Pass/Pass.h"
+#include "polygeist/Passes/Passes.h"
+
+namespace mlir {
+namespace polygeist {
+
+#define GEN_PASS_CLASSES
+#include "polygeist/Passes/Passes.h.inc"
+
+} // namespace polygeist
+}
+
+#endif // DIALECT_POLYGEIST_TRANSFORMS_PASSDETAILS_H

--- a/lib/polygeist/Passes/RaiseToAffine.cpp
+++ b/lib/polygeist/Passes/RaiseToAffine.cpp
@@ -1,3 +1,5 @@
+#include "PassDetails.h"
+
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/Passes.h"
@@ -13,6 +15,7 @@
 
 using namespace mlir;
 using namespace mlir::arith;
+using namespace polygeist;
 
 namespace {
 struct RaiseSCFToAffine : public SCFRaiseToAffineBase<RaiseSCFToAffine> {

--- a/lib/polygeist/Passes/TrivialUse.cpp
+++ b/lib/polygeist/Passes/TrivialUse.cpp
@@ -9,6 +9,7 @@
 // This file implements a pass to lower gpu kernels in NVVM/gpu dialects into
 // a generic parallel for representation
 //===----------------------------------------------------------------------===//
+#include "PassDetails.h"
 
 #include "polygeist/Ops.h"
 #include "polygeist/Passes/Passes.h"
@@ -16,6 +17,7 @@
 #define DEBUG_TYPE "trivial-use"
 
 using namespace mlir;
+using namespace polygeist;
 
 namespace {
 struct RemoveTrivialUse : public RemoveTrivialUseBase<RemoveTrivialUse> {

--- a/tools/polygeist-opt/polygeist-opt.cpp
+++ b/tools/polygeist-opt/polygeist-opt.cpp
@@ -1,0 +1,51 @@
+//===- polygeist-opt.cpp - The polygeist-opt driver -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the 'polygeist-opt' tool, which is the polygeist analog
+// of mlir-opt, used to drive compiler passes, e.g. for testing.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/MlirOptMain.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "polygeist/Dialect.h"
+#include "polygeist/Passes/Passes.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+
+  // Register MLIR stuff
+  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::memref::MemRefDialect>();
+  registry.insert<mlir::StandardOpsDialect>();
+  registry.insert<mlir::arith::ArithmeticDialect>();
+  registry.insert<mlir::scf::SCFDialect>();
+
+  registry.insert<mlir::polygeist::PolygeistDialect>();
+
+  mlir::registerpolygeistPasses();
+
+  // Register the standard passes we want.
+  mlir::registerCSEPass();
+  mlir::registerSCCPPass();
+  mlir::registerInlinerPass();
+  mlir::registerCanonicalizerPass();
+
+  return mlir::failed(mlir::MlirOptMain(
+      argc, argv, "Polygeist modular optimizer driver", registry,
+      /*preloadDialectsInContext=*/false));
+}


### PR DESCRIPTION
This commit adds a `polygeist-opt` command line tool. This allows us to drive each of the polygeist passes individually and as such lays the foundation for adding tests of the individual passes and create new passes which depend on the Polygeist dialect and drive these outside of `mlir-clang`.

In doing so, a fair bit of restructuring/modifications of the various namespaces, function names etc. employed in the passes have been done. This was mostly due to inconsistensies in symbol names and namespaces which weren't being caught as errors due to missing inclusion of pass registration.