### PR TITLE
- Improves createAllocOp to create statically shaped MemRefType.

### DIFF
--- a/mlir-clang/Lib/clang-mlir.h
+++ b/mlir-clang/Lib/clang-mlir.h
@@ -170,7 +170,8 @@ private:
   size_t getTypeSize(clang::QualType t);
 
   mlir::Value createAllocOp(mlir::Type t, VarDecl *name, uint64_t memspace,
-                            bool isArray, bool LLVMABI);
+                            bool isArray = false, bool LLVMABI = false,
+                            mlir::ReassociationIndicesRef shape_out = -1);
 
   const clang::FunctionDecl *EmitCallee(const Expr *E);
 


### PR DESCRIPTION
The PR aims at addressing the [issue-112](https://github.com/wsmoses/Polygeist/issues/112).
The initializeValueByInitListExpr expects the allocated memory generated in VisitVarDecl to be statically shaped MemRefType. The PR also disallows createAllocOp  to create non-MemRefType when called in VisitInitListExpr. The functionality provided in  VisitInitListExpr expects a MemRefType. Moreover the assert on allocated memory  and  initialisation expression, when element type of the allocated memory is a struct type, is modified. 