### PR TITLE
Also link IPO with mlir-clang

### DIFF
--- a/tools/mlir-clang/CMakeLists.txt
+++ b/tools/mlir-clang/CMakeLists.txt
@@ -7,6 +7,7 @@ set( LLVM_LINK_COMPONENTS
   InstCombine
   Instrumentation
   MC
+  IPO
   MCParser
   ObjCARCOpts
   Option


### PR DESCRIPTION
Both locally and [in CI](https://github.com/circt-hls/circt-hls/runs/4593636038?check_suite_focus=true) a reference to `createStripSymbolsPass` is missing. This is defined in libIPO.