### PR TITLE
Add options for cross compilation

### DIFF
--- a/tools/mlir-clang/Lib/clang-mlir.cc
+++ b/tools/mlir-clang/Lib/clang-mlir.cc
@@ -4801,6 +4801,13 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
     chars[ResourceDir.length()] = 0;
     Argv.push_back(chars);
   }
+  if (SysRoot != "") {
+    Argv.push_back("--sysroot");
+    char *chars = (char *)malloc(SysRoot.length() + 1);
+    memcpy(chars, SysRoot.data(), SysRoot.length());
+    chars[SysRoot.length()] = 0;
+    Argv.push_back(chars);
+  }
   if (Verbose) {
     Argv.push_back("-v");
   }

--- a/tools/mlir-clang/Lib/clang-mlir.cc
+++ b/tools/mlir-clang/Lib/clang-mlir.cc
@@ -4773,6 +4773,20 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
   }
   if (FOpenMP)
     Argv.push_back("-fopenmp");
+  if (TargetTripleOpt != "") {
+    char *chars = (char *)malloc(TargetTripleOpt.length() + 1);
+    memcpy(chars, TargetTripleOpt.data(), TargetTripleOpt.length());
+    chars[TargetTripleOpt.length()] = 0;
+    Argv.push_back("-target");
+    Argv.push_back(chars);
+  }
+  if (McpuOpt != "") {
+    auto a = "-mcpu=" + McpuOpt;
+    char *chars = (char *)malloc(a.length() + 1);
+    memcpy(chars, a.data(), a.length());
+    chars[a.length()] = 0;
+    Argv.push_back(chars);
+  }
   if (Standard != "") {
     auto a = "-std=" + Standard;
     char *chars = (char *)malloc(a.length() + 1);

--- a/tools/mlir-clang/Test/Verification/triple.cu
+++ b/tools/mlir-clang/Test/Verification/triple.cu
@@ -1,0 +1,7 @@
+// RUN: mlir-clang --target aarch64-unknown-linux-gnu %s %stdinclude -S -o - | FileCheck %s -check-prefix=MLIR
+// RUN: mlir-clang --target aarch64-unknown-linux-gnu %s %stdinclude -emit-llvm -S -o - | FileCheck %s -check-prefix=LLVM
+
+// MLIR:  llvm.target_triple = "aarch64-unknown-linux-gnu"
+// LLVM:  target triple = "aarch64-unknown-linux-gnu"
+
+int main() { return 0; }

--- a/tools/mlir-clang/mlir-clang.cc
+++ b/tools/mlir-clang/mlir-clang.cc
@@ -117,6 +117,9 @@ static cl::opt<std::string> MArch("march", cl::init(""),
 static cl::opt<std::string> ResourceDir("resource-dir", cl::init(""),
                                         cl::desc("Resource-dir"));
 
+static cl::opt<std::string> SysRoot("sysroot", cl::init(""),
+                                    cl::desc("sysroot"));
+
 static cl::opt<bool> EarlyVerifier("early-verifier", cl::init(false),
                                    cl::desc("Enable verifier ASAP"));
 
@@ -284,6 +287,8 @@ int emitBinary(char *Argv0, const char *filename,
 
   if (ResourceDir != "")
     driver->ResourceDir = ResourceDir;
+  if (SysRoot != "")
+    driver->SysRoot = SysRoot;
   SmallVector<std::pair<int, const Command *>, 4> FailingCommands;
   int Res = 0;
 

--- a/tools/mlir-clang/mlir-clang.cc
+++ b/tools/mlir-clang/mlir-clang.cc
@@ -136,6 +136,13 @@ static cl::list<std::string> defines("D", cl::desc("defines"),
 static cl::list<std::string> Includes("include", cl::desc("includes"),
                                       cl::cat(toolOptions));
 
+static cl::opt<std::string> TargetTripleOpt("target", cl::init(""),
+                                            cl::desc("Target triple"),
+                                            cl::cat(toolOptions));
+
+static cl::opt<std::string>
+    McpuOpt("mcpu", cl::init(""), cl::desc("Target CPU"), cl::cat(toolOptions));
+
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 class MemRefInsider
@@ -210,9 +217,14 @@ int emitBinary(char *Argv0, const char *filename,
 
   DiagnosticsEngine Diags(DiagID, &*DiagOpts, DiagBuffer);
 
+  string TargetTriple;
+  if (TargetTripleOpt == "")
+    TargetTriple = llvm::sys::getDefaultTargetTriple();
+  else
+    TargetTriple = TargetTripleOpt;
+
   const char *binary = Argv0;
-  const unique_ptr<Driver> driver(
-      new Driver(binary, llvm::sys::getDefaultTargetTriple(), Diags));
+  const unique_ptr<Driver> driver(new Driver(binary, TargetTriple, Diags));
   driver->CC1Main = &ExecuteCC1Tool;
   std::vector<const char *> Argv;
   Argv.push_back(Argv0);


### PR DESCRIPTION
These options enabled me to cross compile an aarch64 object file which I was then able to link and run natively on aarch64.