### PR TITLE
Clang-tidy (NFC)

### DIFF
--- a/lib/polygeist/Ops.cpp
+++ b/lib/polygeist/Ops.cpp
@@ -1514,7 +1514,7 @@ struct MoveIntoIfs : public OpRewritePattern<scf::IfOp> {
     if (nextIf == &parent->front())
       return failure();
 
-    auto prevOp = nextIf->getPrevNode();
+    auto *prevOp = nextIf->getPrevNode();
 
     // Only move if op doesn't write or free memory (only read)
     if (!wouldOpBeTriviallyDead(prevOp))
@@ -1633,8 +1633,8 @@ struct MoveOutOfIfs : public OpRewritePattern<scf::IfOp> {
       }
 
     rewriter.setInsertionPoint(nextIf);
-    for (auto o : toMove) {
-      auto rep = rewriter.clone(*o);
+    for (auto *o : toMove) {
+      auto *rep = rewriter.clone(*o);
       rewriter.replaceOp(o, rep->getResults());
     }
 

--- a/lib/polygeist/Passes/AffineReduction.cpp
+++ b/lib/polygeist/Passes/AffineReduction.cpp
@@ -64,7 +64,7 @@ struct AffineForReductionIter : public OpRewritePattern<AffineForOp> {
 
   bool checkDominance(Operation *a, ArrayRef<Operation *> bs) const {
     bool res = true;
-    for (auto b : bs)
+    for (auto *b : bs)
       if (!checkDominance(b, a)) {
         res = false;
         break;
@@ -106,7 +106,7 @@ struct AffineForReductionIter : public OpRewritePattern<AffineForOp> {
         SmallVector<AffineStoreOp> candidateStores;
         SmallVector<Operation *> otherStores;
         SmallVector<Operation *> otherLoads;
-        for (auto user : memref.getUsers()) {
+        for (auto *user : memref.getUsers()) {
           if (auto store = dyn_cast<AffineStoreOp>(user)) {
             if (areInSameAffineFor(load, store, forOp) &&
                 areCompatible<AffineStoreOp>(load, store)) {
@@ -162,7 +162,7 @@ struct AffineForReductionIter : public OpRewritePattern<AffineForOp> {
     llvm::append_range(newIterArgs, forOp.getRegionIterArgs());
     rewriter.setInsertionPoint(forOp);
     for (auto pair : candidateOpsInFor) {
-      auto movedLoad = rewriter.clone(*std::get<0>(pair));
+      auto *movedLoad = rewriter.clone(*std::get<0>(pair));
       newIterArgs.push_back(movedLoad->getResult(0));
     }
 
@@ -226,7 +226,7 @@ struct AffineForReductionIter : public OpRewritePattern<AffineForOp> {
       auto store = cast<AffineStoreOp>(std::get<1>(pair));
 
       auto loads = loadsInFor[i];
-      for (auto load : loads) {
+      for (auto *load : loads) {
         if (PDT.postDominates(store, load)) {
           load->getResult(0).replaceAllUsesWith(
               newForOp.getBody()->getArguments()[i + origNumRegionArgs + 1]);

--- a/lib/polygeist/Passes/CanonicalizeFor.cpp
+++ b/lib/polygeist/Passes/CanonicalizeFor.cpp
@@ -506,7 +506,7 @@ struct WhileToForHelper {
       return false;
 
     // Cannot transform for if step is not loop-invariant
-    if (auto op = step.getDefiningOp()) {
+    if (auto *op = step.getDefiningOp()) {
       if (loop->isAncestor(op)) {
         return false;
       }
@@ -580,9 +580,9 @@ struct WhileToForHelper {
       lb = rewriter.create<AddIOp>(loop.getLoc(), lb, one);
     }
     if (ub_cloneMove) {
-      auto op = ub.getDefiningOp();
+      auto *op = ub.getDefiningOp();
       assert(op);
-      auto newOp = rewriter.clone(*op);
+      auto *newOp = rewriter.clone(*op);
       rewriter.replaceOp(op, newOp->getResults());
       ub = newOp->getResult(0);
     }
@@ -1384,7 +1384,7 @@ struct RemoveWhileSelect : public OpRewritePattern<WhileOp> {
 
     nop.getBefore().takeBody(loop.getBefore());
 
-    auto after = rewriter.createBlock(&nop.getAfter());
+    auto *after = rewriter.createBlock(&nop.getAfter());
     for (auto y : newYields)
       after->addArgument(y.getType(), loop.getLoc());
 
@@ -1544,7 +1544,7 @@ struct WhileLICM : public OpRewritePattern<WhileOp> {
     // Helper to check whether an operation is loop invariant wrt. SSA
     // properties.
     auto isDefinedOutsideOfBody = [&](Value value) {
-      auto definingOp = value.getDefiningOp();
+      auto *definingOp = value.getDefiningOp();
       if (!definingOp) {
         if (auto ba = value.dyn_cast<BlockArgument>())
           definingOp = ba.getOwner()->getParentOp();
@@ -1722,7 +1722,7 @@ struct ReturnSq : public OpRewritePattern<ReturnOp> {
       changed = true;
       toErase.push_back(&*iter);
     }
-    for (auto op : toErase) {
+    for (auto *op : toErase) {
       rewriter.eraseOp(op);
     }
     return success(changed);

--- a/lib/polygeist/Passes/LoopRestructure.cpp
+++ b/lib/polygeist/Passes/LoopRestructure.cpp
@@ -273,7 +273,7 @@ bool attemptToFoldIntoPredecessor(Block *target) {
 bool LoopRestructure::removeIfFromRegion(DominanceInfo &domInfo, Region &region,
                                          Block *pseudoExit) {
   SmallVector<Block *, 4> Preds;
-  for (auto block : pseudoExit->getPredecessors()) {
+  for (auto *block : pseudoExit->getPredecessors()) {
     Preds.push_back(block);
   }
   SmallVector<Type, 4> emptyTys;
@@ -284,7 +284,7 @@ bool LoopRestructure::removeIfFromRegion(DominanceInfo &domInfo, Region &region,
   if (Preds.size() == 2) {
     for (size_t i = 0; i < Preds.size(); ++i) {
       SmallVector<Block *, 4> Succs;
-      for (auto block : Preds[i]->getSuccessors()) {
+      for (auto *block : Preds[i]->getSuccessors()) {
         Succs.push_back(block);
       }
       if (Succs.size() == 2) {
@@ -334,7 +334,7 @@ bool LoopRestructure::removeIfFromRegion(DominanceInfo &domInfo, Region &region,
               tbuilder.create<scf::YieldOp>(tbuilder.getUnknownLoc(), emptyTys,
                                             condBr.getFalseOperands());
             }
-            auto oldTerm = Succs[1 - j]->getTerminator();
+            auto *oldTerm = Succs[1 - j]->getTerminator();
             OpBuilder tbuilder(Succs[1 - j], Succs[1 - j]->end());
             tbuilder.create<scf::YieldOp>(tbuilder.getUnknownLoc(), emptyTys,
                                           oldTerm->getOperands());
@@ -359,7 +359,7 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
     const llvm::DominatorTreeBase<Block, false> *DT =
         &domInfo.getDomTree(&region);
     mlir::LoopInfo LI(*(const llvm::DominatorTreeBase<Wrapper, false> *)DT);
-    for (auto L : LI.getTopLevelLoops()) {
+    for (auto *L : LI.getTopLevelLoops()) {
       Block *header = (Block *)L->getHeader();
       Block *target = (Block *)L->getUniqueExitBlock();
       if (!target) {
@@ -394,7 +394,7 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
         valsCallingLoop.push_back(a);
 
       SmallVector<std::pair<Value, size_t>> preservedVals;
-      for (auto B : L->getBlocks()) {
+      for (auto *B : L->getBlocks()) {
         for (auto &O : *(Block *)B) {
           for (auto V : O.getResults()) {
             if (llvm::any_of(V.getUsers(), [&](Operation *user) {
@@ -438,7 +438,7 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
 
       SmallVector<Block *, 4> Preds;
 
-      for (auto block : header->getPredecessors()) {
+      for (auto *block : header->getPredecessors()) {
         if (!L->contains((Wrapper *)block))
           Preds.push_back(block);
       }
@@ -611,7 +611,7 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
         yieldargs.push_back(a);
       }
 
-      for (auto block : Preds) {
+      for (auto *block : Preds) {
         Operation *terminator = block->getTerminator();
         for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
           Block *successor = terminator->getSuccessor(i);

--- a/lib/polygeist/Passes/OpenMPOpt.cpp
+++ b/lib/polygeist/Passes/OpenMPOpt.cpp
@@ -133,10 +133,10 @@ struct CombineParallel : public OpRewritePattern<omp::ParallelOp> {
               return nextParallel->isAncestor(user);
             });
           })) {
-        auto prevIter =
+        auto *prevIter =
             (prevOp == &parent->front()) ? nullptr : prevOp->getPrevNode();
         rewriter.setInsertionPointToStart(&nextParallel.getRegion().front());
-        auto replacement = rewriter.clone(*prevOp);
+        auto *replacement = rewriter.clone(*prevOp);
         rewriter.replaceOp(prevOp, replacement->getResults());
         changed = true;
         if (!prevIter)
@@ -180,7 +180,7 @@ struct ParallelForInterchange : public OpRewritePattern<omp::ParallelOp> {
     auto newFor =
         rewriter.create<scf::ForOp>(prevFor.getLoc(), prevFor.getLowerBound(),
                                     prevFor.getUpperBound(), prevFor.getStep());
-    auto yield = nextParallel.getRegion().front().getTerminator();
+    auto *yield = nextParallel.getRegion().front().getTerminator();
     newFor.getRegion().takeBody(prevFor.getRegion());
     rewriter.mergeBlockBefore(&nextParallel.getRegion().front(),
                               newFor.getBody()->getTerminator());
@@ -188,7 +188,7 @@ struct ParallelForInterchange : public OpRewritePattern<omp::ParallelOp> {
     rewriter.create<omp::BarrierOp>(nextParallel.getLoc());
 
     rewriter.setInsertionPointToEnd(&newParallel.getRegion().front());
-    auto newYield = rewriter.clone(*yield);
+    auto *newYield = rewriter.clone(*yield);
     rewriter.eraseOp(yield);
     rewriter.eraseOp(nextParallel);
     rewriter.eraseOp(prevFor);
@@ -229,7 +229,7 @@ struct ParallelIfInterchange : public OpRewritePattern<scf::IfOp> {
     rewriter.setInsertionPointToEnd(&newParallel.getRegion().front());
     auto newIf = rewriter.create<scf::IfOp>(
         prevIf.getLoc(), prevIf.getCondition(), /*hasElse*/ elseParallel);
-    auto yield = nextParallel.getRegion().front().getTerminator();
+    auto *yield = nextParallel.getRegion().front().getTerminator();
     rewriter.mergeBlockBefore(&nextParallel.getRegion().front(),
                               newIf.thenYield());
     if (elseParallel) {

--- a/lib/polygeist/Passes/ParallelLower.cpp
+++ b/lib/polygeist/Passes/ParallelLower.cpp
@@ -155,7 +155,7 @@ mlir::LLVM::LLVMFuncOp GetOrCreateMallocFunction(ModuleOp module) {
   if (auto fn = dyn_cast_or_null<LLVM::LLVMFuncOp>(
           symbolTable.lookupSymbolIn(module, builder.getStringAttr("malloc"))))
     return fn;
-  auto ctx = module->getContext();
+  auto *ctx = module->getContext();
   mlir::Type types[] = {mlir::IntegerType::get(ctx, 64)};
   auto llvmFnType = LLVM::LLVMFunctionType::get(
       LLVM::LLVMPointerType::get(mlir::IntegerType::get(ctx, 8)), types, false);
@@ -174,7 +174,7 @@ mlir::LLVM::LLVMFuncOp GetOrCreateFreeFunction(ModuleOp module) {
   if (auto fn = dyn_cast_or_null<LLVM::LLVMFuncOp>(
           symbolTable.lookupSymbolIn(module, builder.getStringAttr("free"))))
     return fn;
-  auto ctx = module->getContext();
+  auto *ctx = module->getContext();
   auto llvmFnType = LLVM::LLVMFunctionType::get(
       LLVM::LLVMVoidType::get(ctx),
       ArrayRef<mlir::Type>(LLVM::LLVMPointerType::get(builder.getI8Type())),

--- a/lib/polygeist/Passes/RaiseToAffine.cpp
+++ b/lib/polygeist/Passes/RaiseToAffine.cpp
@@ -143,7 +143,7 @@ struct ForOpRaising : public OpRewritePattern<scf::ForOp> {
       // The terminator is added if the iterator args are not provided.
       // see the ::build method.
       if (affineLoop.getNumIterOperands() == 0) {
-        auto affineYieldOp = newBlock.getTerminator();
+        auto *affineYieldOp = newBlock.getTerminator();
         rewriter.eraseOp(affineYieldOp);
       }
 
@@ -250,7 +250,7 @@ struct ParallelOpRaising : public OpRewritePattern<scf::ParallelOp> {
     // The terminator is added if the iterator args are not provided.
     // see the ::build method.
     if (affineLoop.getResults().size() == 0) {
-      auto affineYieldOp = newBlock.getTerminator();
+      auto *affineYieldOp = newBlock.getTerminator();
       rewriter.eraseOp(affineYieldOp);
     }
 

--- a/tools/mlir-clang/Lib/CGCall.cc
+++ b/tools/mlir-clang/Lib/CGCall.cc
@@ -91,15 +91,15 @@ ValueCategory MLIRScanner::CallHelper(
   for (auto pair : arguments) {
 
     ValueCategory arg = std::get<0>(pair);
-    auto a = std::get<1>(pair);
+    auto *a = std::get<1>(pair);
     if (!arg.val) {
       expr->dump();
       a->dump();
     }
     assert(arg.val && "expect not null");
 
-    if (auto ice = dyn_cast_or_null<ImplicitCastExpr>(a))
-      if (auto dre = dyn_cast<DeclRefExpr>(ice->getSubExpr()))
+    if (auto *ice = dyn_cast_or_null<ImplicitCastExpr>(a))
+      if (auto *dre = dyn_cast<DeclRefExpr>(ice->getSubExpr()))
         mapFuncOperands.insert(
             make_pair(dre->getDecl()->getName().str(), arg.val));
 
@@ -244,7 +244,7 @@ ValueCategory MLIRScanner::CallHelper(
     args.push_back(alloc);
   }
 
-  if (auto CU = dyn_cast<CUDAKernelCallExpr>(expr)) {
+  if (auto *CU = dyn_cast<CUDAKernelCallExpr>(expr)) {
     auto l0 = Visit(CU->getConfig()->getArg(0));
     assert(l0.isReference);
     mlir::Value blocks[3];
@@ -300,7 +300,7 @@ ValueCategory MLIRScanner::CallHelper(
                                                   blocks[2], threads[0],
                                                   threads[1], threads[2]);
     auto oldpoint = builder.getInsertionPoint();
-    auto oldblock = builder.getInsertionBlock();
+    auto *oldblock = builder.getInsertionBlock();
     builder.setInsertionPointToStart(&op.getRegion().front());
     builder.create<CallOp>(loc, tocall, args);
     builder.create<gpu::TerminatorOp>(loc);
@@ -355,10 +355,10 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   if (valEmitted.second)
     return valEmitted.first;
 
-  if (auto oc = dyn_cast<CXXOperatorCallExpr>(expr)) {
+  if (auto *oc = dyn_cast<CXXOperatorCallExpr>(expr)) {
     if (oc->getOperator() == clang::OO_EqualEqual) {
-      if (auto lhs = dyn_cast<CXXTypeidExpr>(expr->getArg(0))) {
-        if (auto rhs = dyn_cast<CXXTypeidExpr>(expr->getArg(1))) {
+      if (auto *lhs = dyn_cast<CXXTypeidExpr>(expr->getArg(0))) {
+        if (auto *rhs = dyn_cast<CXXTypeidExpr>(expr->getArg(1))) {
           QualType LT = lhs->isTypeOperand()
                             ? lhs->getTypeOperand(Glob.CGM.getContext())
                             : lhs->getExprOperand()->getType();
@@ -375,17 +375,17 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       }
     }
   }
-  if (auto oc = dyn_cast<CXXMemberCallExpr>(expr)) {
-    if (auto lhs = dyn_cast<CXXTypeidExpr>(oc->getImplicitObjectArgument())) {
+  if (auto *oc = dyn_cast<CXXMemberCallExpr>(expr)) {
+    if (auto *lhs = dyn_cast<CXXTypeidExpr>(oc->getImplicitObjectArgument())) {
       expr->getCallee()->dump();
-      if (auto ic = dyn_cast<MemberExpr>(expr->getCallee()))
-        if (auto sr = dyn_cast<NamedDecl>(ic->getMemberDecl())) {
+      if (auto *ic = dyn_cast<MemberExpr>(expr->getCallee()))
+        if (auto *sr = dyn_cast<NamedDecl>(ic->getMemberDecl())) {
           if (sr->getIdentifier() && sr->getName() == "name") {
             QualType LT = lhs->isTypeOperand()
                               ? lhs->getTypeOperand(Glob.CGM.getContext())
                               : lhs->getExprOperand()->getType();
             llvm::Constant *LC = Glob.CGM.GetAddrOfRTTIDescriptor(LT);
-            while (auto CE = dyn_cast<llvm::ConstantExpr>(LC))
+            while (auto *CE = dyn_cast<llvm::ConstantExpr>(LC))
               LC = CE->getOperand(0);
             std::string val = cast<llvm::GlobalVariable>(LC)->getName().str();
             return CommonArrayToPointer(ValueCategory(
@@ -396,18 +396,18 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     }
   }
 
-  if (auto ps = dyn_cast<CXXPseudoDestructorExpr>(expr->getCallee())) {
+  if (auto *ps = dyn_cast<CXXPseudoDestructorExpr>(expr->getCallee())) {
     return Visit(ps);
   }
 
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if (sr->getDecl()->getIdentifier() &&
           (sr->getDecl()->getName() == "atomicAdd" ||
            sr->getDecl()->getName() == "atomicOr" ||
            sr->getDecl()->getName() == "atomicAnd")) {
         std::vector<ValueCategory> args;
-        for (auto a : expr->arguments()) {
+        for (auto *a : expr->arguments()) {
           args.push_back(Visit(a));
         }
         auto a0 = args[0].getValue(builder);
@@ -498,8 +498,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     return val;
   };
 
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if (sr->getDecl()->getIdentifier() &&
           (sr->getDecl()->getName() == "__powf" ||
            sr->getDecl()->getName() == "pow" ||
@@ -512,7 +512,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
            sr->getDecl()->getName() == "powf")) {
         auto mlirType = getMLIRType(expr->getType());
         std::vector<mlir::Value> args;
-        for (auto a : expr->arguments()) {
+        for (auto *a : expr->arguments()) {
           args.push_back(Visit(a).getValue(builder));
         }
         if (args[1].getType().isa<mlir::IntegerType>())
@@ -525,8 +525,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
               /*isReference*/ false);
       }
     }
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if (sr->getDecl()->getIdentifier() &&
           sr->getDecl()->getName() == "__builtin_addressof") {
         auto V = Visit(expr->getArg(0));
@@ -555,8 +555,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
         assert(0 && "unhandled builtin addressof");
       }
     }
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if (sr->getDecl()->getIdentifier() &&
           (sr->getDecl()->getName() == "__nv_fabsf" ||
            sr->getDecl()->getName() == "__nv_fabs" ||
@@ -631,7 +631,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
            sr->getDecl()->getName() == "strlen")) {
         mlir::Value V0 = getLLVM(expr->getArg(0));
 
-        auto name = "strlen";
+        const auto *name = "strlen";
 
         if (Glob.functions.find(name) == Glob.functions.end()) {
           std::vector<mlir::Type> types{V0.getType()};
@@ -935,8 +935,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       }
     }
 
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if ((sr->getDecl()->getIdentifier() &&
            (sr->getDecl()->getName() == "fscanf" ||
             sr->getDecl()->getName() == "scanf" ||
@@ -945,13 +945,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
           (isa<CXXOperatorCallExpr>(expr) &&
            cast<CXXOperatorCallExpr>(expr)->getOperator() ==
                OO_GreaterGreater)) {
-        auto tocall = EmitCallee(expr->getCallee());
+        const auto *tocall = EmitCallee(expr->getCallee());
         auto strcmpF = Glob.GetOrCreateLLVMFunction(tocall);
 
         std::vector<mlir::Value> args;
         std::vector<std::pair<mlir::Value, mlir::Value>> ops;
         std::map<const void *, size_t> counts;
-        for (auto a : expr->arguments()) {
+        for (auto *a : expr->arguments()) {
           auto v = getLLVM(a);
           if (auto toptr = v.getDefiningOp<polygeist::Memref2PointerOp>()) {
             auto T = toptr.getType().cast<LLVM::LLVMPointerType>();
@@ -973,8 +973,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       }
     }
 
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if (sr->getDecl()->getIdentifier() &&
           (sr->getDecl()->getName() == "memmove" ||
            sr->getDecl()->getName() == "__builtin_memmove")) {
@@ -1014,11 +1014,11 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
            sr->getDecl()->getName() == "cudaMemcpyToSymbol" ||
            sr->getDecl()->getName() == "memcpy" ||
            sr->getDecl()->getName() == "__builtin_memcpy")) {
-        auto dstSub = expr->getArg(0);
-        while (auto BC = dyn_cast<clang::CastExpr>(dstSub))
+        auto *dstSub = expr->getArg(0);
+        while (auto *BC = dyn_cast<clang::CastExpr>(dstSub))
           dstSub = BC->getSubExpr();
-        auto srcSub = expr->getArg(1);
-        while (auto BC = dyn_cast<clang::CastExpr>(srcSub))
+        auto *srcSub = expr->getArg(1);
+        while (auto *BC = dyn_cast<clang::CastExpr>(srcSub))
           srcSub = BC->getSubExpr();
 
 #if 0
@@ -1323,7 +1323,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     }
 #endif
 
-  auto callee = EmitCallee(expr->getCallee());
+  const auto *callee = EmitCallee(expr->getCallee());
 
   std::set<std::string> funcs = {
       "fread",
@@ -1373,13 +1373,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       "cudaOccupancyMaxActiveBlocksPerMultiprocessor",
       "cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags",
       "cudaEventRecord"};
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
+  if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
+    if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       StringRef name;
-      if (auto CC = dyn_cast<CXXConstructorDecl>(sr->getDecl()))
+      if (auto *CC = dyn_cast<CXXConstructorDecl>(sr->getDecl()))
         name =
             Glob.CGM.getMangledName(GlobalDecl(CC, CXXCtorType::Ctor_Complete));
-      else if (auto CC = dyn_cast<CXXDestructorDecl>(sr->getDecl()))
+      else if (auto *CC = dyn_cast<CXXDestructorDecl>(sr->getDecl()))
         name =
             Glob.CGM.getMangledName(GlobalDecl(CC, CXXDtorType::Dtor_Complete));
       else if (sr->getDecl()->hasAttr<CUDAGlobalAttr>())
@@ -1392,7 +1392,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
           name.startswith("cblas_")) {
 
         std::vector<mlir::Value> args;
-        for (auto a : expr->arguments()) {
+        for (auto *a : expr->arguments()) {
           args.push_back(getLLVM(a));
         }
         mlir::Value called;
@@ -1418,7 +1418,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   if (!callee || callee->isVariadic()) {
     bool isReference = expr->isLValue() || expr->isXValue();
     std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
+    for (auto *a : expr->arguments()) {
       args.push_back(getLLVM(a));
     }
     mlir::Value called;
@@ -1460,7 +1460,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   SmallVector<std::pair<ValueCategory, clang::Expr *>> args;
   QualType objType;
 
-  if (auto CC = dyn_cast<CXXMemberCallExpr>(expr)) {
+  if (auto *CC = dyn_cast<CXXMemberCallExpr>(expr)) {
     ValueCategory obj = Visit(CC->getImplicitObjectArgument());
     objType = CC->getObjectType();
     if (!obj.val) {
@@ -1476,7 +1476,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     assert(obj.isReference);
     args.emplace_back(make_pair(obj, (clang::Expr *)nullptr));
   }
-  for (auto a : expr->arguments())
+  for (auto *a : expr->arguments())
     args.push_back(make_pair(Visit(a), a));
   return CallHelper(tocall, objType, args, expr->getType(),
                     expr->isLValue() || expr->isXValue(), expr);

--- a/tools/mlir-clang/Lib/TypeUtils.cc
+++ b/tools/mlir-clang/Lib/TypeUtils.cc
@@ -32,24 +32,24 @@ bool isRecursiveStruct(Type *T, Type *Meta, SmallPtrSetImpl<Type *> &seen) {
 }
 
 Type *anonymize(Type *T) {
-  if (auto PT = dyn_cast<PointerType>(T))
+  if (auto *PT = dyn_cast<PointerType>(T))
     return PointerType::get(anonymize(PT->getPointerElementType()),
                             PT->getAddressSpace());
-  if (auto AT = dyn_cast<ArrayType>(T))
+  if (auto *AT = dyn_cast<ArrayType>(T))
     return ArrayType::get(anonymize(AT->getElementType()),
                           AT->getNumElements());
-  if (auto FT = dyn_cast<FunctionType>(T)) {
+  if (auto *FT = dyn_cast<FunctionType>(T)) {
     SmallVector<Type *, 4> V;
-    for (auto t : FT->params())
+    for (auto *t : FT->params())
       V.push_back(anonymize(t));
     return FunctionType::get(anonymize(FT->getReturnType()), V, FT->isVarArg());
   }
-  if (auto ST = dyn_cast<StructType>(T)) {
+  if (auto *ST = dyn_cast<StructType>(T)) {
     if (ST->isLiteral())
       return ST;
     SmallVector<Type *, 4> V;
 
-    for (auto t : ST->elements()) {
+    for (auto *t : ST->elements()) {
       SmallPtrSet<Type *, 4> Seen;
       if (isRecursiveStruct(t, ST, Seen))
         V.push_back(t);

--- a/tools/mlir-clang/mlir-clang.cc
+++ b/tools/mlir-clang/mlir-clang.cc
@@ -273,7 +273,7 @@ int emitBinary(char *Argv0, const char *filename,
     chars[Output.length()] = 0;
     Argv.push_back(chars);
   }
-  for (auto arg : LinkArgs)
+  for (const auto *arg : LinkArgs)
     Argv.push_back(arg);
 
   const unique_ptr<Compilation> compilation(


### PR DESCRIPTION
run-clang-tidy -fix ../tools/mlir-clang/Lib/* -checks=-*,llvm*

Checks:

llvm-header-guard
llvm-include-order
llvm-namespace-comment
llvm-prefer-isa-or-dyn-cast-in-conditionals
llvm-prefer-register-over-unsigned
llvm-qualified-auto
llvm-twine-local